### PR TITLE
Update to use pooled connection for polling events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ project/target
 dependency-reduced-pom.xml
 /bin/
 .DS_Store
+.databricks
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>spark-salesforce</artifactId>
     <packaging>jar</packaging>
     <description>spark-salesforce</description>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
     <name>spark-salesforce</name>
     <organization>
         <name>com.springml</name>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,16 @@
             <version>1.0.0</version>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>3.14.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>logging-interceptor</artifactId>
+            <version>3.14.2</version>
+        </dependency>
+        <dependency>
             <groupId>com.frejo</groupId>
             <artifactId>force-rest-api</artifactId>
             <version>0.0.42</version>

--- a/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
+++ b/src/main/scala/com/springml/spark/salesforce/BulkRelation.scala
@@ -95,7 +95,7 @@ case class BulkRelation(
           val writer = new CsvWriter(outputWriter, writerSettings)
           parsedInput.foreach { writer.writeRow(_) }
 
-          outputWriter.toString.lines.toList
+          outputWriter.toString.split("\n").toList
         }
 
         splitCsvByRows(result)

--- a/src/main/scala/com/springml/spark/salesforce/SFObjectWriter.scala
+++ b/src/main/scala/com/springml/spark/salesforce/SFObjectWriter.scala
@@ -32,6 +32,19 @@ class SFObjectWriter(
 
   @transient val logger = Logger.getLogger(classOf[SFObjectWriter])
 
+  // Single BulkAPI instance reused for all driver-side operations (createJob,
+  // closeJob, isCompleted). SFConfig.getPartnerConnection() is lazy, so this
+  // performs exactly ONE SOAP login for the entire driver-side lifecycle.
+  // Marked @transient because BulkAPI is not serializable — executors must
+  // create their own instances via newBulkAPI().
+  @transient private lazy val driverBulkAPI: BulkAPI = newBulkAPI()
+
+  // Fresh instance for executor-side operations (addBatch inside
+  // mapPartitionsWithIndex). Each partition authenticates once.
+  private def newBulkAPI(): BulkAPI = {
+    APIFactory.getInstance().bulkAPI(username, password, login, version)
+  }
+
   def writeData(rdd: RDD[Row]): Boolean = {
 
     val csvRDD = rdd.map { row =>
@@ -46,10 +59,8 @@ class SFObjectWriter(
 
     val jobInfo = new JobInfo(WaveAPIConstants.STR_CSV, sfObject, operation(mode, upsert))
     jobInfo.setExternalIdFieldName(externalIdFieldName)
-//    jobInfo.setConcurrencyMode("Serial")
-//    jobInfo.setNumberRetries("10")
 
-    val jobId = bulkAPI.createJob(jobInfo).getId
+    val jobId = driverBulkAPI.createJob(jobInfo).getId
 
     partitionedRDD.mapPartitionsWithIndex {
       case (index, iterator) => {
@@ -57,21 +68,19 @@ class SFObjectWriter(
         var batchInfoId: String = null
         if (records != null && !records.isEmpty()) {
           val data = csvHeader + "\n" + records
-          val batchInfo = bulkAPI.addBatch(jobId, data)
+          val batchInfo = newBulkAPI().addBatch(jobId, data)
           batchInfoId = batchInfo.getId
         }
 
         val success = (batchInfoId != null)
-        // Job status will be checked after completing all batches
         List(success).iterator
       }
     }.reduce((a, b) => a & b)
 
-    bulkAPI.closeJob(jobId)
+    driverBulkAPI.closeJob(jobId)
     var i = 1
     while (i < 999999) {
-      val isComplete = bulkAPI.isCompleted(jobId)
-      if (bulkAPI.isCompleted(jobId)) {
+      if (driverBulkAPI.isCompleted(jobId)) {
         logger.info("Job completed")
         return true
       }
@@ -83,11 +92,6 @@ class SFObjectWriter(
     print("Returning false...")
     logger.info("Job not completed. Timeout...")
     false
-  }
-
-  // Create new instance of BulkAPI every time because Spark workers cannot serialize the object
-  private def bulkAPI(): BulkAPI = {
-    APIFactory.getInstance().bulkAPI(username, password, login, version)
   }
 
   private def operation(mode: SaveMode, upsert: Boolean): String = {

--- a/src/main/scala/com/springml/spark/salesforce/SFObjectWriter2.scala
+++ b/src/main/scala/com/springml/spark/salesforce/SFObjectWriter2.scala
@@ -38,16 +38,7 @@ class SFObjectWriter2(val username: String,
       ).mkString(",")
     }
 
-//    val partitionCnt = (1 + csvRDD.count() / batchSize).toInt
-//    val partitionedRDD = csvRDD.repartition(partitionCnt)
-
-//    val jobInfo = new JobInfo(WaveAPIConstants.STR_CSV, sfObject, operation(mode, upsert))
-//    jobInfo.setExternalIdFieldName(externalIdFieldName)
-    //    jobInfo.setConcurrencyMode("Serial")
-
-    //    jobInfo.setNumberRetries("10")
     val OperationEnum = operation(mode, upsert)
-//    val jobId = bulkAPI.createJob(jobInfo).getId
     var bulkJobIDs = csvRDD.mapPartitionsWithIndex {
       case (index, iterator) => {
 
@@ -55,22 +46,21 @@ class SFObjectWriter2(val username: String,
         var batchInfoId: String = null
         var id = ""
         if (records != null && !records.isEmpty()) {
-          val createResponse = client.createJob(sfObject, OperationEnum)
+          val partitionClient = newClient()
+          val createResponse = partitionClient.createJob(sfObject, OperationEnum)
           id = createResponse.getId
           val data = csvHeader + "\n" + records
-//          val batchInfo = bulkAPI.addBatch(jobId, data)
-//          batchInfoId = batchInfo.getId
-          client.uploadJobData(id, data)
-          client.closeJob(createResponse.getId)
-//          id = createResponse.getId
+          partitionClient.uploadJobData(id, data)
+          partitionClient.closeJob(createResponse.getId)
         }
 
-//        val success = (batchInfoId != null)
-        // Job status will be checked after completing all batches
         List(id).iterator
       }
     }.collect().filter(_ != null)
     val allIds = bulkJobIDs
+
+    // Single client instance for all driver-side polling (1 SOAP login total)
+    val pollingClient = newClient()
 
     var i = 1
     var failedRecords = 0
@@ -82,15 +72,14 @@ class SFObjectWriter2(val username: String,
       try {
        data = bulkJobIDs.map{
         id =>
-          client.getJobInfo(id)
+          pollingClient.getJobInfo(id)
       }
       failedRecords += data.map(x => x.getNumberRecordsFailed.toInt).sum
 
-//      val printFailedResults = new BufferedReader(client.getJobFailedRecordResults(data.head))
       data.foreach{
         x => if (x.getNumberRecordsFailed != 0) {
           logger.info(s"${x.getRetries} number of retries")
-          val results = new BufferedReader(client.getJobFailedRecordResults(x.getId))
+          val results = new BufferedReader(pollingClient.getJobFailedRecordResults(x.getId))
           results.lines().iterator().asScala.foreach{
             line =>
               println(line)
@@ -130,26 +119,17 @@ class SFObjectWriter2(val username: String,
 
   }
 
-//  // Create new instance of BulkAPI every time because Spark workers cannot serialize the object
-//  private def bulkAPI(): BulkAPI = {
-//    APIFactory.getInstance().bulkAPI(username, password, login, version)
-//  }
-//  val bulkAPIClient = new ForceApi(new ApiConfig()
-//  .setUsername(username)
-//  .setPassword(password)
-//  .setLoginEndpoint(login)
-//  .setApiVersion(ApiVersion.V48)
-//)
-  private def bulkAPIClient(): ForceApi = {
-  new ForceApi(new ApiConfig()
-    .setUsername(username)
-    .setPassword(password)
-    .setLoginEndpoint(login)
-    .setApiVersion(ApiVersion.V48))
-}
-  private  def client() = {
-
-    new Bulk2ClientBuilder().withSessionId(bulkAPIClient.getSession.getAccessToken, bulkAPIClient.getSession.getApiEndpoint)
+  // Authenticate once, reuse session for building Bulk2Client instances.
+  // ForceApi is not serializable, so executors call newClient() to get their own.
+  private def newClient(): Bulk2Client = {
+    val api = new ForceApi(new ApiConfig()
+      .setUsername(username)
+      .setPassword(password)
+      .setLoginEndpoint(login)
+      .setApiVersion(ApiVersion.V48))
+    val session = api.getSession
+    new Bulk2ClientBuilder()
+      .withSessionId(session.getAccessToken, session.getApiEndpoint)
       .build()
   }
 
@@ -157,16 +137,13 @@ class SFObjectWriter2(val username: String,
     if (upsert) {
       OperationEnum.UPSERT
     } else if (mode != null && SaveMode.Overwrite.name().equalsIgnoreCase(mode.name())) {
-//      WaveAPIConstants.STR_UPDATE
       OperationEnum.UPDATE
     } else if (mode != null && SaveMode.Append.name().equalsIgnoreCase(mode.name())) {
-//      WaveAPIConstants.STR_INSERT
       OperationEnum.INSERT
     } else {
       logger.warn("SaveMode " + mode + " Not supported. Using 'insert' operation")
       OperationEnum.INSERT
     }
   }
-
 
 }


### PR DESCRIPTION
Working with the SFDC team, Josh discovered that our jobs are collectively exceeding the hourly quota of 3600 sessions/hour. The cause of most of the volume seems to be the status polling. 

For example, one task, the reverse ETL for Opportunity in loan report, makes approximately 400 connections for uploading one table. It should be closer to a dozen connections, one for the driver and one per partition

We'll use a shared session with a lazy BulkAPI object to address this issue.